### PR TITLE
Enable builds for 2015-2018, post builds to more permanent location

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,4 +5,4 @@
 def lvVersions = ['2015', '2016', '2017', '2018']
 
 ni.vsbuild.PipelineExecutor.execute(this, 'veristand', lvVersions)
-diffPipeline('2015')
+diffPipeline(lvVersions[0])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 //Leave the above line alone.  It identifies this as a groovy script.
 @Library('vs-build-tools') _
 
-def lvVersions = ['2018']
+def lvVersions = ['2015', '2016', '2017', '2018']
 
 ni.vsbuild.PipelineExecutor.execute(this, 'veristand', lvVersions)
-diffPipeline('2018')
+diffPipeline('2015')

--- a/build.toml
+++ b/build.toml
@@ -1,6 +1,6 @@
 [archive]
 build_output_dir = 'Built'
-archive_location = '\\nirvana\temp\vs_cds\ni_system_monitor_custom_device'
+archive_location = '\\nirvana\Measurements\VeriStandAddons\ni_system_monitor_custom_device'
 
 [projects.cd]
 path = 'Source\System Monitor Custom Device.lvproj'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-system-monitor-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Enable builds for 2015-2018, post builds to more permanent location

### Why should this Pull Request be merged?
Right now we only build for 2018, and our builds are ephemeral.

### What testing has been done?
This pull request will be built.
