### PR TITLE
Build 2016-2019

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 //Leave the above line alone.  It identifies this as a groovy script.
 @Library('vs-build-tools') _
 
-def lvVersions = ['2015', '2016', '2017', '2018']
+def lvVersions = ['2016', '2017', '2018', '2019']
 
 ni.vsbuild.PipelineExecutor.execute(this, 'veristand', lvVersions)
 diffPipeline(lvVersions[0])


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-system-monitor-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Builds custom device for versions 2016-2019

### Why should this Pull Request be merged?

Custom devices will be released with 2019. We should be able to run the monitor with 2019.

### What testing has been done?

None
