### PR TITLE
Build nipkg for 32- and 64-bit

### DIFF
--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: ni-system-monitor-veristand-{veristand_version}-support
 Version: {nipkg_version}
-Architecture: windows_x64
+Architecture: windows_all
 Maintainer: National Instruments <support@ni.com>
 XB-Plugin: file
 Description: Provides support for the system monitor custom device for NI VeriStand {veristand_version}.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-system-monitor-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Allows nipkg to be installed on 32-bit machines.

### Why should this Pull Request be merged?

Don't artificially limit to 64-bit machines.

### What testing has been done?

Waiting for build.
