### PR TITLE
Add "NI" prefix to display name

### DIFF
--- a/control
+++ b/control
@@ -11,5 +11,5 @@ XB-LanguageSupport: en
 XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
-XB-DisplayName: System Monitor for VeriStand {veristand_version}
+XB-DisplayName: NI System Monitor for VeriStand {veristand_version}
 Depends: ni-veristand-{labview_version} (>= {labview_short_version}.0.0)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-system-monitor-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add an "NI" prefix to the nipkg display name.

### Why should this Pull Request be merged?

The other custom device packages have an "NI" prefix.

### What testing has been done?

N/A
