### PR TITLE
Enable 2023 build, disable 2019 build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,8 @@
 @Library('vs-build-tools') _
 
 def lvVersions = [
-  32 : ['2019', '2020'],
-  64 : ['2021']
+  32 : ['2020'],
+  64 : ['2021', '2023']
 ]
 
 diffPipeline(lvVersions)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-system-monitor-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enable a build supporting VeriStand 2023.

### Why should this Pull Request be merged?

We need a good build against in-dev 2023 to run automated testing.

### What testing has been done?

Successful branch build.
