### PR TITLE
Bump version to 26.0.0, drop 2023 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@ The System Monitor Custom Device can only be used on an RT Target. Deploying a S
 
 ## Development Version
 
-LabVIEW 2023
+LabVIEW 2024
 
 ## Dependencies
 
 ### Running the custom device
 
-- [VeriStand 2023 or later](https://www.ni.com/en-us/support/downloads/software-products/download.veristand.html)
+- [VeriStand 2024 or later](https://www.ni.com/en-us/support/downloads/software-products/download.veristand.html)
 
 ### Developing or building from source
 
-- [LabVIEW 2023 or later](https://www.ni.com/en-us/support/downloads/software-products/download.labview.html)
+- [LabVIEW 2024 or later](https://www.ni.com/en-us/support/downloads/software-products/download.labview.html)
 - [LabVIEW Real-Time Module](https://www.ni.com/en-us/support/downloads/software-products/download.labview-real-time-module.html)
 - [VeriStand Custom Device Development Tools](https://github.com/ni/niveristand-custom-device-development-tools)
   - Install the latest package from the [release page](https://github.com/ni/niveristand-custom-device-development-tools/releases)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,11 +17,11 @@ stages:
   - template: azure-templates/stages.yml@niveristand-custom-device-build-tools
     parameters:
       lvVersionsToBuild:
-        - version: '2023'
-          bitness: '64bit'
         - version: '2024'
           bitness: '64bit'
         - version: '2025'
+          bitness: '64bit'
+        - version: '2026'
           bitness: '64bit'
 
       buildSteps:
@@ -35,7 +35,7 @@ stages:
           target: 'All'
           buildSpec: 'Engine Release'
 
-      releaseVersion: '25.0.0'
+      releaseVersion: '26.0.0'
       buildOutputLocation: 'Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\ni_system_monitor_custom_device'
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-system-monitor-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add new lv, Bump version to 26.0.0, drop 2023 build

### Why should this Pull Request be merged?

future release

### What testing has been done?

PR build
