### PR TITLE
Scheduled pipeline to run everyday at 6PM IST

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,13 @@ resources:
       endpoint:   nivs-custom-devices
       name:       ni/niveristand-custom-device-build-tools
 
+schedules:
+- cron: '30 12 * * *'
+  displayName: Daily 6 PM (IST) build
+  branches:
+    include:
+    - main
+
 stages:
   - template: azure-templates/stages.yml@niveristand-custom-device-build-tools
     parameters:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-system-monitor-custom-device/blob/main/CONTRIBUTING.md).

## What does this Pull Request accomplish?
This PR schedules the niveristand-system-monitor-custom-device pipeline to run automatically every day at 6:00 PM IST.

## Why should this Pull Request be merged?
To automatically trigger the pipeline.

## What testing has been done?
NA